### PR TITLE
Specify language of the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,7 +86,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
With Sphinx 5.0.0 language set to None is treated as Warning, which causes
documentation build to fail during tests. This should solve the issue.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>