### PR TITLE
Clean remaining dependabot references

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,13 +4,13 @@ queue_rules:
       - check-success=fedora/check
 
 pull_request_rules:
-  - name: dependabot
+  - name: renovate
     actions:
       queue:
         method: rebase
         name: default
     conditions:
-    - author=dependabot[bot]
+    - author=renovate[bot]
     - label!=no-mergify
     - "#changes-requested-reviews-by=0"
     - check-success=fedora/check


### PR DESCRIPTION
Remove dependabot configuration and update mergify with renovate.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>