### PR TITLE
Update schemas with some missing properties needed for FMN

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,10 +5,10 @@ include =
 
 
 [report]
-fail_under = 88
+fail_under = 100
 precision = 2
 exclude_lines =
     pragma: no cover
     if __name__ == .__main__.:
 omit =
-    anitya_schema/anitya_schema/tests/*
+    anitya_schema/tests/*

--- a/anitya_schema/base.py
+++ b/anitya_schema/base.py
@@ -14,7 +14,10 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import warnings
+
 from fedora_messaging import message
+from fedora_messaging.schema_utils import user_avatar_url
 
 ANITYA_URL = "https://release-monitoring.org/"
 
@@ -31,3 +34,36 @@ class AnityaMessage(message.Message):
             the name of the application (anitya)
         """
         return "anitya"
+
+    @property
+    def agent(self):
+        """Return the agent's username for this message.
+
+        Returns:
+            The agent's username
+        """
+        warnings.warn(
+            "agent property is deprecated, please use agent_name instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.agent_name
+
+    @property
+    def agent_name(self):
+        """Return the agent's username for this message.
+
+        Returns:
+            The agent's username
+        """
+        return self.body["message"]["agent"]
+
+    @property
+    def agent_avatar(self):
+        """
+        Return a URL to the avatar of the user who caused the action.
+
+        Returns:
+            The URL to the user's avatar, or None if username is None.
+        """
+        return user_avatar_url(self.agent_name)

--- a/anitya_schema/base.py
+++ b/anitya_schema/base.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2018-2023 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from fedora_messaging import message
+
+ANITYA_URL = "https://release-monitoring.org/"
+
+
+class AnityaMessage(message.Message):
+    """A base class for Anitya messages."""
+
+    @property
+    def app_name(self):
+        """
+        Return the name of the application that generated the message.
+
+        Returns:
+            the name of the application (anitya)
+        """
+        return "anitya"

--- a/anitya_schema/distro_messages.py
+++ b/anitya_schema/distro_messages.py
@@ -66,11 +66,6 @@ class DistroCreated(AnityaMessage):
         )
 
     @property
-    def agent(self):
-        """User that did the change."""
-        return self.body["message"]["agent"]
-
-    @property
     def distro_name(self):
         """The new distribution's name."""
         return self.body["distro"]["name"]
@@ -136,11 +131,6 @@ class DistroEdited(AnityaMessage):
         return "The name of the {} distribution changed to {}.".format(
             self.distro_name_old, self.distro_name_new
         )
-
-    @property
-    def agent(self):
-        """User that did the change."""
-        return self.body["message"]["agent"]
 
     @property
     def distro_name_new(self):
@@ -214,11 +204,6 @@ class DistroDeleted(AnityaMessage):
         return "The {} distribution was removed from release-monitoring.".format(
             self.distro_name
         )
-
-    @property
-    def agent(self):
-        """User that did the change."""
-        return self.body["message"]["agent"]
 
     @property
     def distro_name(self):

--- a/anitya_schema/distro_messages.py
+++ b/anitya_schema/distro_messages.py
@@ -15,12 +15,10 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """The schema for distribution-related messages sent by Anitya."""
 
-from fedora_messaging import message
-
-ANITYA_URL = "https://release-monitoring.org/"
+from .base import AnityaMessage, ANITYA_URL
 
 
-class DistroCreated(message.Message):
+class DistroCreated(AnityaMessage):
     """
     Message sent by Anitya to the "anitya.distro.add" topic when a new
     distribution is added.
@@ -83,7 +81,7 @@ class DistroCreated(message.Message):
         return ANITYA_URL + "distros/" + self.distro_name
 
 
-class DistroEdited(message.Message):
+class DistroEdited(AnityaMessage):
     """
     Message sent by Anitya when a distribution is edited.
 
@@ -165,7 +163,7 @@ class DistroEdited(message.Message):
         return ANITYA_URL + "distros/" + self.distro_name_old
 
 
-class DistroDeleted(message.Message):
+class DistroDeleted(AnityaMessage):
     """
     Message sent by Anitya when a distribution is removed.
 

--- a/anitya_schema/project_messages.py
+++ b/anitya_schema/project_messages.py
@@ -16,12 +16,10 @@
 """The schema for project-related messages sent by Anitya."""
 import warnings
 
-from fedora_messaging import message
-
-ANITYA_URL = "https://release-monitoring.org/"
+from .base import AnityaMessage, ANITYA_URL
 
 
-class ProjectMessage(message.Message):
+class ProjectMessage(AnityaMessage):
     """
     Base class for every project message.
 
@@ -336,7 +334,7 @@ class ProjectFlag(ProjectMessage):
         return self.body["message"]["reason"]
 
 
-class ProjectFlagSet(message.Message):
+class ProjectFlagSet(AnityaMessage):
     """
     Sent when a flag is closed for a project.
 

--- a/anitya_schema/project_messages.py
+++ b/anitya_schema/project_messages.py
@@ -142,11 +142,6 @@ class ProjectCreated(ProjectMessage):
             self.project_name
         )
 
-    @property
-    def agent(self):
-        """User that did the action."""
-        return self.body["message"]["agent"]
-
 
 class ProjectEdited(ProjectMessage):
     """
@@ -201,11 +196,6 @@ class ProjectEdited(ProjectMessage):
             self.project_name
         )
 
-    @property
-    def agent(self):
-        """User that did the action."""
-        return self.body["message"]["agent"]
-
 
 class ProjectDeleted(ProjectMessage):
     """
@@ -251,11 +241,6 @@ class ProjectDeleted(ProjectMessage):
         return "A project, {}, was deleted in release-monitoring.".format(
             self.project_name
         )
-
-    @property
-    def agent(self):
-        """User that did the action."""
-        return self.body["message"]["agent"]
 
 
 class ProjectFlag(ProjectMessage):
@@ -307,11 +292,6 @@ class ProjectFlag(ProjectMessage):
         return "A flag was created on project {} in release-monitoring.".format(
             self.project_name
         )
-
-    @property
-    def agent(self):
-        """User that did the action."""
-        return self.body["message"]["agent"]
 
     @property
     def mappings(self):
@@ -376,11 +356,6 @@ class ProjectFlagSet(AnityaMessage):
     def summary(self):
         """Return a summary of the message."""
         return "A flag '{}' was {} in release-monitoring.".format(self.flag, self.state)
-
-    @property
-    def agent(self):
-        """User that did the action."""
-        return self.body["message"]["agent"]
 
     @property
     def flag(self):
@@ -454,11 +429,6 @@ class ProjectMapCreated(ProjectCreated):
         return self.body["distro"]["name"]
 
     @property
-    def agent(self):
-        """User that did the action."""
-        return self.body["message"]["agent"]
-
-    @property
     def package_name(self):
         """Package name for the new mapping."""
         return self.body["message"]["new"]
@@ -522,11 +492,6 @@ class ProjectMapEdited(ProjectMessage):
         return self.body["distro"]["name"]
 
     @property
-    def agent(self):
-        """User that did the action."""
-        return self.body["message"]["agent"]
-
-    @property
     def edited(self):
         """List of edited fields."""
         return self.body["message"]["edited"]
@@ -586,11 +551,6 @@ class ProjectMapDeleted(ProjectMessage):
         return "A mapping for project {} was deleted in release-monitoring.".format(
             self.project_name
         )
-
-    @property
-    def agent(self):
-        """User that did the action."""
-        return self.body["message"]["agent"]
 
     @property
     def distro(self):
@@ -678,11 +638,6 @@ class ProjectVersionUpdated(ProjectMessage):
                 self.version, self.project_name
             )
         )
-
-    @property
-    def agent(self):
-        """User that did the action."""
-        return self.body["message"]["agent"]
 
     @property
     def old_version(self):
@@ -787,11 +742,6 @@ class ProjectVersionUpdatedV2(ProjectMessage):
         )
 
     @property
-    def agent(self):
-        """User that did the action."""
-        return self.body["message"]["agent"]
-
-    @property
     def old_version(self):
         """Old version of project."""
         return self.body["message"]["old_version"]
@@ -889,11 +839,6 @@ class ProjectVersionDeleted(ProjectMessage):
         )
 
     @property
-    def agent(self):
-        """User that did the action."""
-        return self.body["message"]["agent"]
-
-    @property
     def version(self):
         """The version that was deleted."""
         return self.body["message"]["version"]
@@ -952,11 +897,6 @@ class ProjectVersionDeletedV2(ProjectMessage):
             return "{} versions entries were deleted in project {} in release-monitoring.".format(
                 len(self.versions), self.project_name
             )
-
-    @property
-    def agent(self):
-        """User that did the action."""
-        return self.body["message"]["agent"]
 
     @property
     def versions(self):

--- a/anitya_schema/tests/test_base.py
+++ b/anitya_schema/tests/test_base.py
@@ -17,7 +17,7 @@
 
 import unittest
 
-from anitya_schema import ProjectCreated
+from anitya_schema import DistroCreated
 
 
 class TestAnityaMessage(unittest.TestCase):
@@ -27,8 +27,31 @@ class TestAnityaMessage(unittest.TestCase):
         """Set up the tests."""
         # We can't use AnityaMessage directly,
         # so we will use something that inherits it
-        self.message = ProjectCreated()
+        self.message = DistroCreated(
+            {
+                "project": None,
+                "message": {"agent": "dudemcpants", "distro": "Pants Linux"},
+                "distro": {"name": "PantsLinux"},
+            }
+        )
+        self.message.validate()
 
     def test_app_name(self):
         """Assert that app_name is correct."""
         self.assertEqual(self.message.app_name, "anitya")
+
+    def test_agent_avatar(self):
+        """Assert that agent_avartar is correct."""
+        self.assertEqual(
+            self.message.agent_avatar,
+            (
+                "https://seccdn.libravatar.org/avatar/caa750edf4a112068"
+                "31a58713cf9231b5b3227765887cbc765d4f8c5c55576a5?s=64&d=retro"
+            ),
+        )
+
+    def test_agent_deprecation_warning(self):
+        with self.assertWarnsRegex(DeprecationWarning, r"agent property is deprecated"):
+            agent = self.message.agent
+        assert agent == "dudemcpants"
+        assert agent == self.message.agent_name

--- a/anitya_schema/tests/test_base.py
+++ b/anitya_schema/tests/test_base.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2018-2023  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Unit tests for the base AnityaMessage message class."""
+
+import unittest
+
+from anitya_schema import ProjectCreated
+
+
+class TestAnityaMessage(unittest.TestCase):
+    """Tests for AnityaMessage class."""
+
+    def setUp(self):
+        """Set up the tests."""
+        # We can't use AnityaMessage directly,
+        # so we will use something that inherits it
+        self.message = ProjectCreated()
+
+    def test_app_name(self):
+        """Assert that app_name is correct."""
+        self.assertEqual(self.message.app_name, "anitya")

--- a/anitya_schema/tests/test_distro_messages.py
+++ b/anitya_schema/tests/test_distro_messages.py
@@ -49,11 +49,11 @@ class TestDistroCreated(unittest.TestCase):
         exp = "A new distribution, Dummy, was added to release-monitoring."
         self.assertEqual(self.message.summary, exp)
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        self.assertEqual(self.message.agent, "Dummy")
+        self.assertEqual(self.message.agent_name, "Dummy")
 
     def test_distro_name(self):
         """Assert that distro name is returned."""
@@ -103,11 +103,11 @@ class TestDistroEdited(unittest.TestCase):
         exp = "The name of the Old name distribution changed to New name."
         self.assertEqual(self.message.summary, exp)
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        self.assertEqual(self.message.agent, "Dummy")
+        self.assertEqual(self.message.agent_name, "Dummy")
 
     def test_name_new(self):
         """Assert that new_name string is returned."""
@@ -166,11 +166,11 @@ class TestDistroDeleted(unittest.TestCase):
         exp = "The Dummy distribution was removed from release-monitoring."
         self.assertEqual(self.message.summary, exp)
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        self.assertEqual(self.message.agent, "Dummy")
+        self.assertEqual(self.message.agent_name, "Dummy")
 
     def test_distro_name(self):
         """Assert that distro name is returned."""

--- a/anitya_schema/tests/test_project_messages.py
+++ b/anitya_schema/tests/test_project_messages.py
@@ -123,11 +123,11 @@ class TestProjectCreated(unittest.TestCase):
         exp = "A new project, Dummy, was added to release-monitoring."
         self.assertEqual(self.message.summary, exp)
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        self.assertEqual(self.message.agent, "Dummy")
+        self.assertEqual(self.message.agent_name, "Dummy")
 
 
 class TestProjectEdited(unittest.TestCase):
@@ -158,11 +158,11 @@ class TestProjectEdited(unittest.TestCase):
         exp = "A project, Dummy, was edited in release-monitoring."
         self.assertEqual(self.message.summary, exp)
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        self.assertEqual(self.message.agent, "Dummy")
+        self.assertEqual(self.message.agent_name, "Dummy")
 
 
 class TestProjectDeleted(unittest.TestCase):
@@ -193,11 +193,11 @@ class TestProjectDeleted(unittest.TestCase):
         exp = "A project, Dummy, was deleted in release-monitoring."
         self.assertEqual(self.message.summary, exp)
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        self.assertEqual(self.message.agent, "Dummy")
+        self.assertEqual(self.message.agent_name, "Dummy")
 
 
 class TestProjectFlag(unittest.TestCase):
@@ -228,11 +228,11 @@ class TestProjectFlag(unittest.TestCase):
         exp = "A flag was created on project Dummy in release-monitoring."
         self.assertEqual(self.message.summary, exp)
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        self.assertEqual(self.message.agent, "Dummy")
+        self.assertEqual(self.message.agent_name, "Dummy")
 
     def test_mappings(self):
         """Assert that array of mappings is returned."""
@@ -296,11 +296,11 @@ class TestProjectFlagSet(unittest.TestCase):
         exp = "A flag '007' was closed in release-monitoring."
         self.assertEqual(self.message.summary, exp)
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        self.assertEqual(self.message.agent, "Dummy")
+        self.assertEqual(self.message.agent_name, "Dummy")
 
     def test_flag(self):
         """Assert that flag string is returned."""
@@ -353,11 +353,11 @@ class TestProjectMapCreated(unittest.TestCase):
 
         self.assertEqual(self.message.distro, "Dummy")
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        self.assertEqual(self.message.agent, "Dummy")
+        self.assertEqual(self.message.agent_name, "Dummy")
 
     def test_package_name(self):
         """Assert that package name string is returned."""
@@ -400,11 +400,11 @@ class TestProjectMapEdited(unittest.TestCase):
 
         self.assertEqual(self.message.distro, "Dummy")
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        self.assertEqual(self.message.agent, "Dummy")
+        self.assertEqual(self.message.agent_name, "Dummy")
 
     def test_edited(self):
         """Assert that list of edited fields is returned."""
@@ -453,11 +453,11 @@ class TestProjectMapDeleted(unittest.TestCase):
         exp = "A mapping for project Dummy was deleted in release-monitoring."
         self.assertEqual(self.message.summary, exp)
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        self.assertEqual(self.message.agent, "Dummy")
+        self.assertEqual(self.message.agent_name, "Dummy")
 
     def test_distro(self):
         """Assert that distro name string is returned."""
@@ -510,11 +510,11 @@ class TestProjectVersionUpdated(unittest.TestCase):
         exp = "A new version '1.0.0' was found for project Dummy in release-monitoring."
         self.assertEqual(self.message.summary, exp)
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        self.assertEqual(self.message.agent, "Dummy")
+        self.assertEqual(self.message.agent_name, "Dummy")
 
     def test_old_version(self):
         """Assert that old version is returned."""
@@ -600,11 +600,11 @@ class TestProjectVersionUpdatedV2(unittest.TestCase):
         exp = "A new versions '1.0.0, 0.9.0' were found for project Dummy in release-monitoring."
         self.assertEqual(self.message.summary, exp)
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        self.assertEqual(self.message.agent, "Dummy")
+        self.assertEqual(self.message.agent_name, "Dummy")
 
     def test_old_version(self):
         """Assert that old version is returned."""
@@ -690,11 +690,11 @@ class TestProjectVersionDeleted(unittest.TestCase):
         exp = "A version '1.0.0' was deleted in project Dummy in release-monitoring."
         self.assertEqual(self.message.summary, exp)
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        self.assertEqual(self.message.agent, "Dummy")
+        self.assertEqual(self.message.agent_name, "Dummy")
 
     def test_version(self):
         """Assert that version string is returned."""
@@ -756,11 +756,11 @@ class TestProjectVersionDeletedV2:
 
         assert self.message.summary == expected
 
-    def test_agent(self):
-        """Assert that agent is returned."""
+    def test_agent_name(self):
+        """Assert that agent_name is returned."""
         self.message.body = {"message": {"agent": "Dummy"}}
 
-        assert self.message.agent == "Dummy"
+        assert self.message.agent_name == "Dummy"
 
     def test_versions(self):
         """Assert that version string is returned."""


### PR DESCRIPTION
This adds a few missing properties:
* changing agent to agent_name
* adding app_name

There are a couple that we need for FMN which i dont think apply for anitya:

* usernames -- all the messages sent by anitya don't know anything about users (other than the person that made the change, the agent_name, so dont really need this IMO)
* groups -- anitya doenst know anything about FAS groups
* artifacts -- while anitya does map distros to packages, its kind of in a meta sense, so not really an "artifact" yet, so didnt do this one. If we did we would have to hardcode Fedora here maybe, and its a bit icky.