### PR TITLE
Set the `packages` property when relevant

### DIFF
--- a/anitya_schema/project_messages.py
+++ b/anitya_schema/project_messages.py
@@ -433,6 +433,14 @@ class ProjectMapCreated(ProjectCreated):
         """Package name for the new mapping."""
         return self.body["message"]["new"]
 
+    @property
+    def packages(self):
+        """Fedora packages related to the change."""
+        if self.distro == "Fedora":
+            return [self.package_name]
+        else:
+            return []
+
 
 class ProjectMapEdited(ProjectMessage):
     """
@@ -505,6 +513,15 @@ class ProjectMapEdited(ProjectMessage):
     def package_name_prev(self):
         """Previous package name for the mapping."""
         return self.body["message"]["prev"]
+
+    @property
+    def packages(self):
+        """Fedora packages related to the change."""
+        if self.distro != "Fedora":
+            return []
+        pkgs = list(set([self.package_name_prev, self.package_name_new]))
+        pkgs.sort()
+        return pkgs
 
 
 class ProjectMapDeleted(ProjectMessage):
@@ -778,6 +795,15 @@ class ProjectVersionUpdatedV2(ProjectMessage):
     def stable_versions(self):
         """All stable versions on the project."""
         return self.body["message"]["stable_versions"]
+
+    @property
+    def packages(self):
+        """Fedora packages related to the change."""
+        return [
+            package["package_name"]
+            for package in self.body["message"]["packages"]
+            if package["distro"] == "Fedora"
+        ]
 
 
 class ProjectVersionDeleted(ProjectMessage):

--- a/anitya_schema/tests/test_project_messages.py
+++ b/anitya_schema/tests/test_project_messages.py
@@ -362,6 +362,13 @@ class TestProjectMapCreated:
 
         assert self.message.package_name == "Dummy"
 
+    @pytest.mark.parametrize("distro,packages", [("Fedora", ["dummy"]), ("CentOS", [])])
+    def test_packages_fedora(self, distro, packages):
+        """Assert that packages list is filled only when it's on Fedora"""
+        self.message.body = {"distro": {"name": distro}, "message": {"new": "dummy"}}
+
+        assert self.message.packages == packages
+
 
 class TestProjectMapEdited:
     """Tests for anitya_schema.project_messages.ProjectMapEdited class."""
@@ -421,6 +428,26 @@ class TestProjectMapEdited:
 
         assert self.message.package_name_prev == "Dummy"
 
+    @pytest.mark.parametrize(
+        "distro,packages", [("Fedora", ["dummy", "dummy_prev"]), ("CentOS", [])]
+    )
+    def test_packages_fedora(self, distro, packages):
+        """Assert that packages list is filled only when it's on Fedora"""
+        self.message.body = {
+            "distro": {"name": distro},
+            "message": {"prev": "dummy_prev", "new": "dummy"},
+        }
+        assert self.message.packages == packages
+
+    @pytest.mark.parametrize("distro,packages", [("Fedora", ["dummy"]), ("CentOS", [])])
+    def test_packages_fedora_same_package(self, distro, packages):
+        """Assert that packages list is filled only when it's on Fedora"""
+        self.message.body = {
+            "distro": {"name": distro},
+            "message": {"prev": "dummy", "new": "dummy"},
+        }
+        assert self.message.packages == packages
+
 
 class TestProjectMapDeleted:
     """Tests for anitya_schema.project_messages.ProjectMapDeleted class."""
@@ -461,6 +488,14 @@ class TestProjectMapDeleted:
         self.message.body = {"message": {"distro": "Dummy"}}
 
         assert self.message.distro == "Dummy"
+
+    @pytest.mark.skip("The package name is not part of the message")
+    @pytest.mark.parametrize("distro,packages", [("Fedora", ["dummy"]), ("CentOS", [])])
+    def test_packages_fedora(self, distro, packages):
+        """Assert that packages list is filled only when it's on Fedora"""
+        self.message.body = {"distro": {"name": distro}, "message": {"old": "dummy"}}
+
+        assert self.message.packages == packages
 
 
 class TestProjectVersionUpdated:
@@ -657,6 +692,18 @@ class TestProjectVersionUpdatedV2:
 
         assert self.message.stable_versions == ["1.0.0", "0.9.0"]
 
+    def test_packages_fedora(self):
+        """Assert that packages list is filled only when it's on Fedora"""
+        self.message.body = {
+            "message": {
+                "packages": [
+                    {"distro": "Fedora", "package_name": "package_fedora"},
+                    {"distro": "CentOS", "package_name": "package_centos"},
+                ]
+            }
+        }
+        assert self.message.packages == ["package_fedora"]
+
 
 class TestProjectVersionDeleted:
     """Tests for anitya_schema.project_messages.ProjectVersionDeleted class."""
@@ -768,3 +815,11 @@ class TestProjectVersionDeletedV2:
         self.message.body = {"message": {"versions": ["1.0.0"]}}
 
         assert self.message.versions == ["1.0.0"]
+
+    @pytest.mark.skip("The package name is not part of the message")
+    @pytest.mark.parametrize("distro,packages", [("Fedora", ["dummy"]), ("CentOS", [])])
+    def test_packages_fedora(self, distro, packages):
+        """Assert that packages list is filled only when it's on Fedora"""
+        self.message.body = {"message": {"distro": distro, "package": "dummy"}}
+
+        assert self.message.packages == packages


### PR DESCRIPTION
The `packages` property can be set on the messages when they concern Fedora. This will let Fedora contributors be notified by FMN when something happens to their packages.

Related: https://github.com/fedora-infra/fmn/issues/1058